### PR TITLE
MET-1577: added info when no persistent version is present for a record

### DIFF
--- a/tools/resource-migration-tool/src/main/java/eu/europeana/cloud/migrator/ResourceMigrator.java
+++ b/tools/resource-migration-tool/src/main/java/eu/europeana/cloud/migrator/ResourceMigrator.java
@@ -1660,15 +1660,25 @@ public class ResourceMigrator {
                     if (representations == null || representations.isEmpty()) {
                         continue;
                     }
+
+                    boolean noPersistentVersion = true;
+
                     for (Representation representation : representations) {
-                        if (representation.isPersistent() && !accessible(representation)) {
-                            // in this case there are no permissions
-                            if (!simulate) {
-                                mcs.permitVersion(cloudId, representation.getRepresentationName(), representation.getVersion());
+                        if (representation.isPersistent()) {
+                            noPersistentVersion = false;
+                            if (!accessible(representation)) {
+                                // in this case there are no permissions
+                                if (!simulate) {
+                                    mcs.permitVersion(cloudId, representation.getRepresentationName(), representation.getVersion());
+                                }
+                                strings.add(localId + ";no permissions for persistent version");
+                                break;
                             }
-                            strings.add(localId + ";no permissions for persistent version");
-                            break;
                         }
+                    }
+
+                    if (noPersistentVersion) {
+                        strings.add(localId + ";no persistent version");
                     }
                 }
             }


### PR DESCRIPTION
When no persistent version is available for a record it will be logged however any granting will not be done because in case of more than one versions it is not possible to automatically detect which version should be persisted.