### PR TITLE
MET-6135 Corrections in the depublication

### DIFF
--- a/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/controller/TopologyTasksResource.java
+++ b/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/controller/TopologyTasksResource.java
@@ -251,13 +251,15 @@ public class TopologyTasksResource {
                                                                         .sentTimestamp(sentTime)
                                                                         .startTimestamp(new Date())
                                                                         .finishTimestamp(null)
-                                                                        .expectedRecordsNumber(0)
+                                                                        .expectedRecordsNumber(
+                                                                            TaskInfo.UNKNOWN_EXPECTED_RECORDS_NUMBER)
                                                                         .processedRecordsCount(0)
                                                                         .ignoredRecordsCount(0)
                                                                         .deletedRecordsCount(0)
                                                                         .processedErrorsCount(0)
                                                                         .deletedErrorsCount(0)
-                                                                        .expectedPostProcessedRecordsNumber(-1)
+                                                                        .expectedPostProcessedRecordsNumber(
+                                                                            TaskInfo.UNKNOWN_EXPECTED_RECORDS_NUMBER)
                                                                         .postProcessedRecordsCount(0)
                                                                         .definition(taskJSON)
                                                                         .build()

--- a/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/services/SubmitTaskService.java
+++ b/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/services/SubmitTaskService.java
@@ -49,7 +49,12 @@ public class SubmitTaskService {
   }
 
   private String prepareExceptionMessage(TaskSubmissionException exception) {
-    return String.format("%s (Source issue: %s)", exception.getMessage(), exception.getCause().getMessage());
+    String message = exception.getMessage();
+    Throwable cause = exception.getCause();
+    if (cause != null) {
+      message += String.format(" (Source issue: %s)", cause.getMessage());
+    }
+    return message;
   }
 }
 

--- a/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/utils/UnfinishedTasksExecutor.java
+++ b/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/utils/UnfinishedTasksExecutor.java
@@ -118,6 +118,7 @@ public class UnfinishedTasksExecutor {
                                                  .stateDescription(
                                                      "The task is in a pending mode, it is being processed before submission")
                                                  .definition(taskInfo.getDefinition())
+                                                 .expectedRecordsNumber(taskInfo.getExpectedRecordsNumber())
                                                  .build())
                                .task(dpsTask)
                                .restarted(true).build();

--- a/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/utils/files/counter/DepublicationFilesCounter.java
+++ b/service/dps/rest/src/main/java/eu/europeana/cloud/service/dps/utils/files/counter/DepublicationFilesCounter.java
@@ -20,12 +20,11 @@ public class DepublicationFilesCounter extends FilesCounter {
   public int getFilesCount(DpsTask task) throws TaskSubmissionException {
     if (task.getParameter(PluginParameterKeys.RECORD_IDS_TO_DEPUBLISH) != null) {
       return calculateRecordsNumber(task);
-    }
-    if (task.getParameter(PluginParameterKeys.METIS_DATASET_ID) != null) {
+    } else if (task.getParameter(PluginParameterKeys.METIS_DATASET_ID) != null) {
       return calculateDatasetSize(task);
+    } else {
+      throw new TaskSubmissionException("Can't evaluate task expected size! Needed parameters not found in the task");
     }
-    throw new TaskSubmissionException("Can't evaluate task expected size! Needed parameters not found in the task");
-
   }
 
   private int calculateDatasetSize(DpsTask task) throws TaskSubmissionException {
@@ -35,9 +34,6 @@ public class DepublicationFilesCounter extends FilesCounter {
       if (expectedSize > Integer.MAX_VALUE) {
         throw new TaskSubmissionException(
             "There are " + expectedSize + " records in set. It exceeds Integer size and is not supported.");
-      }
-      if (expectedSize <= 0) {
-        throw new TaskSubmissionException("Not found any publicised records of dataset for task " + task.getTaskId());
       }
       return (int) expectedSize;
     } catch (IndexingException e) {

--- a/service/dps/storm/common/src/main/java/eu/europeana/cloud/service/dps/storm/utils/TaskStatusUpdater.java
+++ b/service/dps/storm/common/src/main/java/eu/europeana/cloud/service/dps/storm/utils/TaskStatusUpdater.java
@@ -79,6 +79,11 @@ public class TaskStatusUpdater {
         processedErrorsCount, deletedErrorsCount);
   }
 
+  public void updateState(long taskId, TaskState state)
+      throws NoHostAvailableException, QueryExecutionException {
+    updateState(taskId, state, state.getDefaultMessage());
+  }
+
   public void updateState(long taskId, TaskState state, String info)
       throws NoHostAvailableException, QueryExecutionException {
     updateTasksByTaskStateTable(taskId, state);

--- a/service/dps/storm/topologies/depublication/src/main/java/eu/europeana/cloud/service/dps/storm/topologies/depublication/DepublicationBolt.java
+++ b/service/dps/storm/topologies/depublication/src/main/java/eu/europeana/cloud/service/dps/storm/topologies/depublication/DepublicationBolt.java
@@ -43,7 +43,7 @@ public class DepublicationBolt extends AbstractDpsBolt {
       if (removedSuccessfully) {
         cleanRecordInHarvestedRecordsTable(metisDatasetId, recordEuropeanaId);
         emitSuccessNotification(anchorTuple, stormTaskTuple);
-        LOGGER.info("The the record: {} successfully depublished.", recordEuropeanaId);
+        LOGGER.info("The the record: {} successfully depublished, because of: {}.", recordEuropeanaId, depublicationReason);
       } else {
         emitErrorNotification(anchorTuple, stormTaskTuple, "Record could not be depublished!",
             "Could not find the record: " + recordEuropeanaId);


### PR DESCRIPTION
1. Corrected NullPointer occuring in the code catching TaskSubmitException and therefore tasks stuck in some situations.
2. Corrected task size counting in the depublication service. 
3. Implemented canceling in the depublication phase of sending records to a Kafka server.